### PR TITLE
Use HTTPS wherever possible

### DIFF
--- a/couscous.yml
+++ b/couscous.yml
@@ -2,7 +2,7 @@ templateUrl: https://github.com/myclabs/couscous-template
 
 template:
     # Base URL of the published website
-    baseUrl: http://myclabs.github.io/ACL
+    baseUrl: https://myclabs.github.io/ACL
 
     github:
         user: myclabs
@@ -46,7 +46,7 @@ template:
                 items:
                     work:
                         text: '<i class="fa fa-github"></i> MyCLabs\Work'
-                        absoluteUrl: http://myclabs.github.io/Work/
+                        absoluteUrl: https://myclabs.github.io/Work/
                     deepcopy:
                         text: '<i class="fa fa-github"></i> MyCLabs\DeepCopy'
                         absoluteUrl: https://github.com/myclabs/DeepCopy
@@ -55,4 +55,4 @@ template:
                         absoluteUrl: https://github.com/myclabs/php-enum
                     jqueryconfirm:
                         text: '<i class="fa fa-github"></i> jquery.confirm'
-                        absoluteUrl: http://myclabs.github.io/jquery.confirm/
+                        absoluteUrl: https://myclabs.github.io/jquery.confirm/

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -84,7 +84,7 @@ That allows to bypass using Doctrine's "cascade remove" which loads all the enti
 be thousands of authorizations).
 
 However this means **your database must support CASCADE operations**. MySQL and PostgreSQL support it,
-but SQLite usually [needs a configuration step](http://www.sqlite.org/foreignkeys.html#fk_enable):
+but SQLite usually [needs a configuration step](https://www.sqlite.org/foreignkeys.html#fk_enable):
 
 ```php
 $entityManager->getConnection()->executeQuery('PRAGMA foreign_keys = ON');


### PR DESCRIPTION
After noticing that the website of https://github.com/myclabs/jquery.confirm/pull/51 is broken when visiting it using HTTPS and doing a PR to fix it there, here's one to fix it for this lib's website, too :) 

As a secure connection is always a good thing and there's no reason for _not_ using it, I changed the URLs to HTTPS whereever possible.
